### PR TITLE
Adds a compile-only Database for unit tests

### DIFF
--- a/src/main/scala/io/github/gaelrenoux/tranzactio/DatabaseModuleBase.scala
+++ b/src/main/scala/io/github/gaelrenoux/tranzactio/DatabaseModuleBase.scala
@@ -1,5 +1,7 @@
 package io.github.gaelrenoux.tranzactio
 
+import java.sql.{Connection => JdbcConnection}
+
 import javax.sql.DataSource
 import zio.blocking.Blocking
 import zio.clock.Clock
@@ -10,6 +12,7 @@ abstract class DatabaseModuleBase[Connection, Dbs <: DatabaseOps.ServiceOps[Conn
   extends DatabaseOps.ModuleOps[Connection, Dbs] {
 
   type Database = Has[Dbs]
+  type Service = DatabaseOps.ServiceOps[Connection]
 
   private[tranzactio]
   override def transactionRFull[R <: Has[_], E, A](
@@ -38,6 +41,9 @@ abstract class DatabaseModuleBase[Connection, Dbs <: DatabaseOps.ServiceOps[Conn
 
   /** Creates a Database Layer which requires an existing ConnectionSource. */
   def fromConnectionSource: ZLayer[ConnectionSource with Blocking, Nothing, Database]
+
+  /** Creates a Tranzactio Connection, given a JDBC connection and a Blocking. Useful for some utilities. */
+  def connectionFromJdbc(env: Blocking, connection: JdbcConnection): ZIO[Any, Nothing, Connection]
 
   /** Commodity method: creates a Database Layer which includes its own ConnectionSource based on a DataSource. Most
    * connection pool implementations should be able to provide you a DataSource.

--- a/src/main/scala/io/github/gaelrenoux/tranzactio/anorm/package.scala
+++ b/src/main/scala/io/github/gaelrenoux/tranzactio/anorm/package.scala
@@ -23,10 +23,8 @@ package object anorm extends Wrapper {
   object Database extends DatabaseModuleBase[Connection, DatabaseOps.ServiceOps[Connection]] {
     self =>
 
-    type Service = DatabaseOps.ServiceOps[Connection]
-
     /** How to provide a Connection for the module, given a JDBC connection and some environment. */
-    def connectionFromJdbc(env: ConnectionSource with Blocking, connection: JdbcConnection): ZIO[Any, Nothing, Connection] =
+    final def connectionFromJdbc(env: Blocking, connection: JdbcConnection): ZIO[Any, Nothing, Connection] =
       ZIO.succeed(Has(connection) ++ env)
 
     /** Creates a Database Layer which requires an existing ConnectionSource. */

--- a/src/main/scala/io/github/gaelrenoux/tranzactio/anorm/package.scala
+++ b/src/main/scala/io/github/gaelrenoux/tranzactio/anorm/package.scala
@@ -2,6 +2,8 @@ package io.github.gaelrenoux.tranzactio
 
 import java.sql.{Connection => JdbcConnection}
 
+import io.github.gaelrenoux.tranzactio.test.DatabaseModuleTestOps
+import izumi.reflect.Tag
 import zio.blocking.{Blocking, effectBlocking}
 import zio.{Has, ZIO, ZLayer}
 
@@ -14,14 +16,20 @@ package object anorm extends Wrapper {
   override final type Query[A] = JdbcConnection => A
   override final type TranzactIO[A] = ZIO[Connection, DbException, A]
 
+  private[tranzactio] val connectionTag = implicitly[Tag[Connection]]
+
   override final def tzio[A](q: Query[A]): TranzactIO[A] =
     ZIO.accessM[Connection] { c =>
       effectBlocking(q(c.get[JdbcConnection]))
     }.mapError(DbException.Wrapped)
 
   /** Database for the Anorm wrapper */
-  object Database extends DatabaseModuleBase[Connection, DatabaseOps.ServiceOps[Connection]] {
+  object Database
+    extends DatabaseModuleBase[Connection, DatabaseOps.ServiceOps[Connection]]
+      with DatabaseModuleTestOps[Connection] {
     self =>
+
+    private[tranzactio] override implicit val connectionTag: Tag[Connection] = anorm.connectionTag
 
     /** How to provide a Connection for the module, given a JDBC connection and some environment. */
     final def connectionFromJdbc(env: Blocking, connection: JdbcConnection): ZIO[Any, Nothing, Connection] =
@@ -35,6 +43,7 @@ package object anorm extends Wrapper {
             self.connectionFromJdbc(env, connection)
         }
       }
+
   }
 
 

--- a/src/main/scala/io/github/gaelrenoux/tranzactio/doobie/package.scala
+++ b/src/main/scala/io/github/gaelrenoux/tranzactio/doobie/package.scala
@@ -39,10 +39,8 @@ package object doobie extends Wrapper {
   object Database extends DatabaseModuleBase[Connection, DatabaseOps.ServiceOps[Connection]] {
     self =>
 
-    type Service = DatabaseOps.ServiceOps[Connection]
-
     /** How to provide a Connection for the module, given a JDBC connection and some environment. */
-    def connectionFromJdbc(env: ConnectionSource with Blocking, connection: JdbcConnection): ZIO[Any, Nothing, Connection] =
+    final def connectionFromJdbc(env: Blocking, connection: JdbcConnection): ZIO[Any, Nothing, Connection] =
       ZCatsBlocker.provide(env).map { b =>
         val connect = (c: JdbcConnection) => Resource.pure[Task, JdbcConnection](c)
         val interp = KleisliInterpreter[Task](b).ConnectionInterpreter

--- a/src/main/scala/io/github/gaelrenoux/tranzactio/test/DatabaseModuleTestOps.scala
+++ b/src/main/scala/io/github/gaelrenoux/tranzactio/test/DatabaseModuleTestOps.scala
@@ -1,0 +1,38 @@
+package io.github.gaelrenoux.tranzactio.test
+
+import io.github.gaelrenoux.tranzactio.{DatabaseModuleBase, DatabaseOps, DbException, ErrorStrategiesRef}
+import izumi.reflect.Tag
+import zio.blocking.Blocking
+import zio.{Has, ZIO, ZLayer}
+
+/** Testing utilities on the Database module. */
+trait DatabaseModuleTestOps[Connection <: Has[_]] extends DatabaseModuleBase[Connection, DatabaseOps.ServiceOps[Connection]] {
+
+  private[tranzactio] implicit val connectionTag: Tag[Connection]
+
+  /** A Connection which is incapable of running anything, to use when unit testing (and the queries are actually stubbed,
+   * so they do not need a Database). Trying to run actual queries against it will fail. */
+  def noConnection(env: Blocking): ZIO[Any, Nothing, Connection] = connectionFromJdbc(env, NoopJdbcConnection)
+
+  /** A Database which is incapable of running anything, to use when unit testing (and the queries are actually stubbed,
+   * so they do not need a Database). Trying to run actual queries against it will fail. */
+  lazy val none: ZLayer[Blocking, Nothing, Database] = ZLayer.fromFunction { b: Blocking =>
+    new Service {
+      override private[tranzactio] def transactionRFull[R <: Has[_], E, A](zio: ZIO[R with Connection, E, A], commitOnFailure: Boolean)
+        (implicit errorStrategies: ErrorStrategiesRef): ZIO[R, Either[DbException, E], A] =
+        noConnection(b).flatMap { c =>
+          zio.provideSome[R] { r: R =>
+            r ++[Connection] c // does not compile without the explicit type
+          }.mapError(Right(_))
+        }
+
+      override private[tranzactio] def autoCommitRFull[R <: Has[_], E, A](zio: ZIO[R with Connection, E, A])
+        (implicit errorStrategies: ErrorStrategiesRef): ZIO[R, Either[DbException, E], A] =
+        noConnection(b).flatMap { c =>
+          zio.provideSome[R] { r: R =>
+            r ++[Connection] c // does not compile without the explicit type
+          }.mapError(Right(_))
+        }
+    }
+  }
+}

--- a/src/main/scala/io/github/gaelrenoux/tranzactio/test/NoopJdbcConnection.scala
+++ b/src/main/scala/io/github/gaelrenoux/tranzactio/test/NoopJdbcConnection.scala
@@ -1,0 +1,118 @@
+package io.github.gaelrenoux.tranzactio.test
+
+import java.sql.{Array => _, _}
+import java.util.Properties
+import java.util.concurrent.Executor
+import java.{sql, util}
+
+/** Java SQL connection implementation, where all methods fail with UnsupportedOperationException. */
+// scalastyle:off number.of.methods
+object NoopJdbcConnection extends Connection {
+  override def createStatement(): Statement = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def prepareStatement(s: String): PreparedStatement = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def prepareCall(s: String): CallableStatement = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def nativeSQL(s: String): String = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def setAutoCommit(b: Boolean): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def getAutoCommit: Boolean = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def commit(): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def rollback(): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def close(): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def isClosed: Boolean = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def getMetaData: DatabaseMetaData = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def setReadOnly(b: Boolean): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def isReadOnly: Boolean = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def setCatalog(s: String): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def getCatalog: String = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def setTransactionIsolation(i: Int): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def getTransactionIsolation: Int = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def getWarnings: SQLWarning = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def clearWarnings(): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def createStatement(i: Int, i1: Int): Statement = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def prepareStatement(s: String, i: Int, i1: Int): PreparedStatement = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def prepareCall(s: String, i: Int, i1: Int): CallableStatement = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def getTypeMap: util.Map[String, Class[_]] = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def setTypeMap(map: util.Map[String, Class[_]]): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def setHoldability(i: Int): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def getHoldability: Int = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def setSavepoint(): Savepoint = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def setSavepoint(s: String): Savepoint = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def rollback(savepoint: Savepoint): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def releaseSavepoint(savepoint: Savepoint): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def createStatement(i: Int, i1: Int, i2: Int): Statement = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def prepareStatement(s: String, i: Int, i1: Int, i2: Int): PreparedStatement = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def prepareCall(s: String, i: Int, i1: Int, i2: Int): CallableStatement = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def prepareStatement(s: String, i: Int): PreparedStatement = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def prepareStatement(s: String, ints: Array[Int]): PreparedStatement = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def prepareStatement(s: String, strings: Array[String]): PreparedStatement = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def createClob(): Clob = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def createBlob(): Blob = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def createNClob(): NClob = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def createSQLXML(): SQLXML = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def isValid(i: Int): Boolean = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def setClientInfo(s: String, s1: String): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def setClientInfo(properties: Properties): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def getClientInfo(s: String): String = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def getClientInfo: Properties = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def createArrayOf(s: String, objects: Array[AnyRef]): sql.Array = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def createStruct(s: String, objects: Array[AnyRef]): Struct = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def setSchema(s: String): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def getSchema: String = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def abort(executor: Executor): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def setNetworkTimeout(executor: Executor, i: Int): Unit = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def getNetworkTimeout: Int = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def unwrap[T](aClass: Class[T]): T = throw new UnsupportedOperationException("NoopJdbcConnection")
+
+  override def isWrapperFor(aClass: Class[_]): Boolean = throw new UnsupportedOperationException("NoopJdbcConnection")
+}

--- a/src/samples/scala/samples/anorm/PersonQueries.scala
+++ b/src/samples/scala/samples/anorm/PersonQueries.scala
@@ -44,6 +44,17 @@ object PersonQueries {
     }
   })
 
+  val test: ULayer[PersonQueries] = ZLayer.succeed(new Service {
+
+    val setup: TranzactIO[Boolean] = ZIO.succeed(true)
+
+    val list: TranzactIO[List[Person]] = ZIO.succeed(Nil)
+
+    def insert(p: Person): TranzactIO[Boolean] = ZIO.succeed(true)
+
+    val failing: TranzactIO[Int] = ZIO.fail(DbException.Wrapped(new RuntimeException))
+  })
+
   def setup: ZIO[PersonQueries with Connection, DbException, Boolean] = ZIO.accessM(_.get.setup)
 
   val list: ZIO[PersonQueries with Connection, DbException, List[Person]] = ZIO.accessM(_.get.list)

--- a/src/samples/scala/samples/anorm/test/SomeTest.scala
+++ b/src/samples/scala/samples/anorm/test/SomeTest.scala
@@ -1,0 +1,36 @@
+package samples.anorm.test
+
+import io.github.gaelrenoux.tranzactio.anorm._
+import samples.anorm.PersonQueries
+import zio._
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment._
+
+/** This is a test where you check you business methods, using stub queries.  */
+object SomeTest extends RunnableSpec[TestEnvironment with Database with PersonQueries, Any] {
+  type Env = TestEnvironment with Database with PersonQueries
+  type Spec = ZSpec[Env, Any]
+
+  /** Using a 'none' Database, because we're not actually using it */
+  lazy val database: ULayer[Database] = testEnvironment >>> Database.none
+
+  /** Using PersonQueries.test her */
+  override def runner: TestRunner[Env, Any] =
+    TestRunner(TestExecutor.default(testEnvironment ++ database ++ PersonQueries.test))
+
+  override def aspects: List[TestAspect[Nothing, Env, Nothing, Any]] = Nil
+
+
+  def spec: Spec = suite("My tests with Anorm")(
+    myTest
+  )
+
+  private val myTest = testM("some test on a method") {
+    for {
+      h <- Database.transactionR[PersonQueries](PersonQueries.list)
+      // do something with that result
+    } yield assert(h)(equalTo(Nil))
+  }
+
+}

--- a/src/samples/scala/samples/doobie/PersonQueries.scala
+++ b/src/samples/scala/samples/doobie/PersonQueries.scala
@@ -51,6 +51,19 @@ object PersonQueries {
     }
   })
 
+  val test: ULayer[PersonQueries] = ZLayer.succeed(new Service {
+
+    val setup: TranzactIO[Unit] = ZIO.succeed(())
+
+    val list: TranzactIO[List[Person]] = ZIO.succeed(Nil)
+
+    val listStream: TranzactIOStream[Person] = ZStream.empty
+
+    def insert(p: Person): TranzactIO[Unit] = ZIO.succeed(())
+
+    val failing: TranzactIO[Unit] = ZIO.fail(DbException.Wrapped(new RuntimeException))
+  })
+
   def setup: ZIO[PersonQueries with Connection, DbException, Unit] = ZIO.accessM(_.get.setup)
 
   val list: ZIO[PersonQueries with Connection, DbException, List[Person]] = ZIO.accessM(_.get.list)

--- a/src/samples/scala/samples/doobie/test/SomeTest.scala
+++ b/src/samples/scala/samples/doobie/test/SomeTest.scala
@@ -1,0 +1,36 @@
+package samples.doobie.test
+
+import io.github.gaelrenoux.tranzactio.doobie._
+import samples.doobie.PersonQueries
+import zio._
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment._
+
+/** This is a test where you check you business methods, using stub queries.  */
+object SomeTest extends RunnableSpec[TestEnvironment with Database with PersonQueries, Any] {
+  type Env = TestEnvironment with Database with PersonQueries
+  type Spec = ZSpec[Env, Any]
+
+  /** Using a 'none' Database, because we're not actually using it */
+  lazy val database: ULayer[Database] = testEnvironment >>> Database.none
+
+  /** Using PersonQueries.test her */
+  override def runner: TestRunner[Env, Any] =
+    TestRunner(TestExecutor.default(testEnvironment ++ database ++ PersonQueries.test))
+
+  override def aspects: List[TestAspect[Nothing, Env, Nothing, Any]] = Nil
+
+
+  def spec: Spec = suite("My tests with Doobie")(
+    myTest
+  )
+
+  private val myTest = testM("some test on a method") {
+    for {
+      h <- Database.transactionR[PersonQueries](PersonQueries.list)
+      // do something with that result
+    } yield assert(h)(equalTo(Nil))
+  }
+
+}


### PR DESCRIPTION
Adds a Database layer that's only useful when required by the compiler, but not actually used. This is actually the case in unit tests, where the queries are typically stubbed. Solves issue #17.