### PR TITLE
Remove the need for specifying R leftovers

### DIFF
--- a/src/test/scala/io/github/gaelrenoux/tranzactio/DatabaseOpsCompileTest.scala
+++ b/src/test/scala/io/github/gaelrenoux/tranzactio/DatabaseOpsCompileTest.scala
@@ -45,11 +45,21 @@ trait DatabaseOpsCompileTest {
     val _: ZIO[Any, DbException, Int] =
       serviceOperations.transactionOrWiden(z[Connection, DbException], commitOnFailure = true)
 
-    /* transactionOrDieR */
+    /* transactionOrDieR (specifying remainder) */
     val _: ZIO[Environment, String, Int] =
       serviceOperations.transactionOrDieR[Environment](z[Connection with Environment, String])
     val _: ZIO[Environment, String, Int] =
       serviceOperations.transactionOrDieR[Environment](z[Connection with Environment, String], commitOnFailure = true)
+    val _: ZIO[Environment, String, Int] =
+      serviceOperations.transactionOrDieR[Environment](z[Connection with Environment, String], commitOnFailure = true)
+
+    /* transactionOrDieR (without specifying remainder) */
+    val _: ZIO[Environment, String, Int] =
+      serviceOperations.transactionOrDieR(z[Connection with Environment, String])
+    val _: ZIO[Environment, String, Int] =
+      serviceOperations.transactionOrDieR(z[Connection with Environment, String], commitOnFailure = true)
+    val _: ZIO[Environment, String, Int] =
+      serviceOperations.transactionOrDieR(z[Connection with Environment, String], commitOnFailure = true)
 
     /* transactionOrDie */
     val _: ZIO[Any, String, Int] =
@@ -65,11 +75,17 @@ trait DatabaseOpsCompileTest {
     val _: ZIO[Any, Either[DbException, String], Int] =
       serviceOperations.autoCommit(z[Connection, String])
 
-    /* autoCommitOrWidenR */
+    /* autoCommitOrWidenR (specifying remainder)*/
     val _: ZIO[Environment, Exception, Int] =
       serviceOperations.autoCommitOrWidenR[Environment](z[Connection with Environment, IllegalArgumentException])
     val _: ZIO[Environment, DbException, Int] =
       serviceOperations.autoCommitOrWidenR[Environment](z[Connection with Environment, DbException])
+
+    /* autoCommitOrWidenR (without specifying remainder)*/
+    val _: ZIO[Environment, Exception, Int] =
+      serviceOperations.autoCommitOrWidenR(z[Connection with Environment, IllegalArgumentException])
+    val c: ZIO[Environment, DbException, Int] =
+      serviceOperations.autoCommitOrWidenR(z[Connection with Environment, DbException])
 
     /* autoCommitOrWiden */
     val _: ZIO[Any, Exception, Int] =
@@ -107,7 +123,7 @@ trait DatabaseOpsCompileTest {
       moduleOperations.transactionOrWiden(z[Connection, DbException])
 
     val _: ZIO[Database with Environment, String, Int] =
-      moduleOperations.transactionOrDieR[Environment](z[Connection with Environment, String])
+      moduleOperations.transactionOrDieR(z[Connection with Environment, String])
     val _: ZIO[Database, String, Int] =
       moduleOperations.transactionOrDie[String, Int](z[Connection, String])
 


### PR DESCRIPTION
Prompted by @hmemcpy earlier, I dug a bit into this consistently frustrating ZIO-related inconvenience; a juicy type-level riddle.

If I'm not crazy, I think I may have found a solution. The fix, it seems, is to reverse the order of the compound type. Given:

```scala
val inferred: ZIO[Environment, String, Int] =
   serviceOperations.transactionOrDieR(z[Connection with Environment, String])
```

```scala
// DOES NOT COMPILE WITH THIS IMPLEMENTATION
final def transactionOrDieR[R <: Has[_], E ,A](
    zio: ZIO[R with Connection, E, A],
    commitOnFailure: Boolean = false
)(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent): ZIO[R with R0, E, A] =
  transactionRFull[R, E, A](zio, commitOnFailure).flatMapError(dieOnLeft)
 
// BUT IT DOES WITH THIS ONE
final def transactionOrDieR[R <: Has[_], E ,A](
    zio: ZIO[Connection with R, E, A],
    commitOnFailure: Boolean = false
)(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent): ZIO[R with R0, E, A] =
  transactionRFull[R, E, A](zio, commitOnFailure).flatMapError(dieOnLeft)
```

Spot the difference? 😜 It's the order of `R with Connection` vs `Connection with R` on the `zio` parameter. 

Turns out, if you put the `R` last, things infer correctly. Thanks a lot Scala 2. So, let it be known: If you wish Scala to delete members from a compound type, put the type parameter at the end. This should be useful in a handful of ZIO libraries if it holds more generally. I still need to poke around some. Also, I might be completely missing something stupid, but I'm excited and so I'm just going to post this anyway :)

Also, I don't think the compile time tests work when the vals are set to `_`. It passed even with the old formulation until I gave them names, they might just be ignored by the compiler. That could just be my local setup though.