### PR TITLE
Remove the need for specifying R leftover environment (continuation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Any constructive criticism, bug report or offer to help is welcome. Just open an
 
 ### Why ?
 
-On my applications, I regularly have quite a bunch of business logics around my queries.
-If I want to run that logic within a transaction, I had to wrap it with Doobie's `ConnectionIO`.
+On my applications, I regularly have quite a bunch of business logics around my queries.
+If I want to run that logic within a transaction, I have to wrap it with Doobie's `ConnectionIO`.
 But I'm already using ZIO as my effect monad! I don't want another one...
-In addition, IO monads on DB libraries (like Doobie's `ConnectionIO`) misses quite a bit of the operations that ZIO has.
+In addition, IO monads on DB libraries (like Doobie's `ConnectionIO`) misses quite a bit of the operations that ZIO has.
 
 That's where TranzactIO comes from. I wanted a way to use ZIO everywhere, and run the transaction whenever I decided.
 
@@ -118,9 +118,9 @@ import zio.console.Console
 val zio: ZIO[Connection, String, Long] = ???
 val simple: ZIO[Database, String, Long] = Database.transactionOrDie(zio)
 
-// If you have an additional environment, use the ***R method. The environment type must be specified.
+// If you have an additional environment, use the ***R method.
 val zioEnv: ZIO[Connection with Console, String, Long] = ???
-val withEnv: ZIO[Database with Console, String, Long] = Database.transactionOrDieR[Console](zioEnv)
+val withEnv: ZIO[Database with Console, String, Long] = Database.transactionOrDieR(zioEnv)
 
 // Do you want to handle connection errors yourself? They will appear on the Left side of the Either.
 val withSeparateErrors: ZIO[Database, Either[DbException, String], Long] = Database.transaction(zio)
@@ -189,6 +189,7 @@ The table below indicates for each version of TranzactIO, the versions of ZIO or
 | 1.0.0      | 1.0.0        | 0.9.0        | 2.6.7        |
 | 1.0.1      | 1.0.0        | 0.9.0        | 2.6.7        |
 | 1.1.0      | 1.0.3        | 0.9.2        | 2.6.7        |
+| 1.2.0      | 1.0.3        | 0.9.2        | 2.6.7        |
 | master     | 1.0.3        | 0.9.2        | 2.6.7        |
 
 
@@ -240,15 +241,13 @@ val result3: ZIO[Database, Exception, A] = Database.transactionOrWiden(zio)
 ```
  
 In addition, a frequent case is to have an additional environment on your ZIO monad, e.g.: `ZIO[ZEnv with Connection, E, A]`.
-To handle this case, all methods mentioned above have an additional variant with a final `R`.
- 
-When using an `***R` method, you will need to provide the additional environment type as a type parameter (Scala's compiler is not smart enough to infer it correctly on its own):
+To handle this case, all methods mentioned above have an additional variant with a final `R`:
 ```scala
 val zio: ZIO[ZEnv with Connection, E, A] = ???
-val result1: ZIO[Database with ZEnv, Either[DbException, E], A] = Database.transactionR[ZEnv](zio)
-val result2: ZIO[Database with ZEnv, E, A] = Database.transactionOrDieR[ZEnv](zio)
+val result1: ZIO[Database with ZEnv, Either[DbException, E], A] = Database.transactionR(zio)
+val result2: ZIO[Database with ZEnv, E, A] = Database.transactionOrDieR(zio)
 // assuming E extends Exception:
-val result3: ZIO[Database with ZEnv, Exception, A] = Database.transactionOrWidenR[ZEnv](zio) 
+val result3: ZIO[Database with ZEnv, Exception, A] = Database.transactionOrWidenR(zio)
 ```
 
 All the `transaction` methods take an optional argument `commitOnFailure` (defaults to `false`).

--- a/src/main/scala/io/github/gaelrenoux/tranzactio/DatabaseModuleBase.scala
+++ b/src/main/scala/io/github/gaelrenoux/tranzactio/DatabaseModuleBase.scala
@@ -14,25 +14,20 @@ abstract class DatabaseModuleBase[Connection, Dbs <: DatabaseOps.ServiceOps[Conn
   type Database = Has[Dbs]
   type Service = DatabaseOps.ServiceOps[Connection]
 
-  private[tranzactio]
-  override def transactionRFull[R <: Has[_], E, A](
-      zio: ZIO[R with Connection, E, A],
+  override def transactionR[R <: Has[_], E, A](
+      zio: ZIO[Connection with R, E, A],
       commitOnFailure: Boolean = false
   )(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent): ZIO[Has[Dbs] with R, Either[DbException, E], A] = {
     ZIO.accessM { db: Has[Dbs] =>
-      db.get[Dbs].transactionRFull[R, E, A](zio, commitOnFailure).provideSome[R] { r =>
-        val env = r ++ Has(()) // needed for the compiler
-        env
-      }
+      db.get[Dbs].transactionR[R, E, A](zio, commitOnFailure)
     }
   }
 
-  private[tranzactio]
-  override def autoCommitRFull[R <: Has[_], E, A](
-      zio: ZIO[R with Connection, E, A]
+  override def autoCommitR[R <: Has[_], E, A](
+      zio: ZIO[Connection with R, E, A]
   )(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent): ZIO[Has[Dbs] with R, Either[DbException, E], A] = {
     ZIO.accessM { db: Has[Dbs] =>
-      db.get[Dbs].autoCommitRFull[R, E, A](zio).provideSome[R] { r =>
+      db.get[Dbs].autoCommitR[R, E, A](zio).provideSome[R] { r =>
         val env = r ++ Has(()) // needed for the compiler
         env
       }

--- a/src/main/scala/io/github/gaelrenoux/tranzactio/DatabaseServiceBase.scala
+++ b/src/main/scala/io/github/gaelrenoux/tranzactio/DatabaseServiceBase.scala
@@ -13,7 +13,7 @@ abstract class DatabaseServiceBase[Connection <: Has[_] : Tag](connectionSource:
 
   def connectionFromJdbc(connection: JdbcConnection): ZIO[Any, Nothing, Connection]
 
-  private[tranzactio] override def transactionRFull[R <: Has[_], E, A](zio: ZIO[R with Connection, E, A], commitOnFailure: Boolean = false)
+  override def transactionR[R <: Has[_], E, A](zio: ZIO[Connection with R, E, A], commitOnFailure: Boolean = false)
     (implicit errorStrategies: ErrorStrategiesRef): ZIO[R, Either[DbException, E], A] =
     ZIO.accessM[R] { r =>
       runTransaction({ c: JdbcConnection =>
@@ -21,7 +21,7 @@ abstract class DatabaseServiceBase[Connection <: Has[_] : Tag](connectionSource:
       }, commitOnFailure)
     }
 
-  private[tranzactio] override def autoCommitRFull[R <: Has[_], E, A](zio: ZIO[R with Connection, E, A])
+  override def autoCommitR[R <: Has[_], E, A](zio: ZIO[Connection with R, E, A])
     (implicit errorStrategies: ErrorStrategiesRef): ZIO[R, Either[DbException, E], A] = {
     ZIO.accessM[R] { r =>
       runAutoCommit { c: JdbcConnection =>

--- a/src/main/scala/io/github/gaelrenoux/tranzactio/test/DatabaseModuleTestOps.scala
+++ b/src/main/scala/io/github/gaelrenoux/tranzactio/test/DatabaseModuleTestOps.scala
@@ -18,7 +18,7 @@ trait DatabaseModuleTestOps[Connection <: Has[_]] extends DatabaseModuleBase[Con
    * so they do not need a Database). Trying to run actual queries against it will fail. */
   lazy val none: ZLayer[Blocking, Nothing, Database] = ZLayer.fromFunction { b: Blocking =>
     new Service {
-      override private[tranzactio] def transactionRFull[R <: Has[_], E, A](zio: ZIO[R with Connection, E, A], commitOnFailure: Boolean)
+      override def transactionR[R <: Has[_], E, A](zio: ZIO[Connection with R, E, A], commitOnFailure: Boolean)
         (implicit errorStrategies: ErrorStrategiesRef): ZIO[R, Either[DbException, E], A] =
         noConnection(b).flatMap { c =>
           zio.provideSome[R] { r: R =>
@@ -26,7 +26,7 @@ trait DatabaseModuleTestOps[Connection <: Has[_]] extends DatabaseModuleBase[Con
           }.mapError(Right(_))
         }
 
-      override private[tranzactio] def autoCommitRFull[R <: Has[_], E, A](zio: ZIO[R with Connection, E, A])
+      override def autoCommitR[R <: Has[_], E, A](zio: ZIO[Connection with R, E, A])
         (implicit errorStrategies: ErrorStrategiesRef): ZIO[R, Either[DbException, E], A] =
         noConnection(b).flatMap { c =>
           zio.provideSome[R] { r: R =>

--- a/src/samples/scala/samples/anorm/LayeredApp.scala
+++ b/src/samples/scala/samples/anorm/LayeredApp.scala
@@ -45,7 +45,7 @@ object LayeredApp extends zio.App {
     ZIO.accessM[AppEnv] { env =>
       // if this implicit is not provided, tranwactio will use Conf.Root.dbRecovery instead
       implicit val errorRecovery: ErrorStrategiesRef = env.get[Conf.Root].alternateDbRecovery
-      Database.transactionOrWidenR[AppEnv](queries)
+      Database.transactionOrWidenR(queries)
     }
   }
 

--- a/src/samples/scala/samples/anorm/test/SomeTest.scala
+++ b/src/samples/scala/samples/anorm/test/SomeTest.scala
@@ -28,7 +28,7 @@ object SomeTest extends RunnableSpec[TestEnvironment with Database with PersonQu
 
   private val myTest = testM("some test on a method") {
     for {
-      h <- Database.transactionR[PersonQueries](PersonQueries.list)
+      h <- Database.transactionR(PersonQueries.list)
       // do something with that result
     } yield assert(h)(equalTo(Nil))
   }

--- a/src/samples/scala/samples/doobie/LayeredApp.scala
+++ b/src/samples/scala/samples/doobie/LayeredApp.scala
@@ -45,7 +45,7 @@ object LayeredApp extends zio.App {
     ZIO.accessM[AppEnv] { env =>
       // if this implicit is not provided, tranzactio will use Conf.Root.dbRecovery instead
       implicit val errorRecovery: ErrorStrategiesRef = env.get[Conf.Root].alternateDbRecovery
-      Database.transactionOrWidenR[AppEnv](queries)
+      Database.transactionOrWidenR(queries)
     }
   }
 

--- a/src/samples/scala/samples/doobie/LayeredAppStreaming.scala
+++ b/src/samples/scala/samples/doobie/LayeredAppStreaming.scala
@@ -50,7 +50,7 @@ object LayeredAppStreaming extends zio.App {
     ZIO.accessM[AppEnv] { env =>
       // if this implicit is not provided, tranzactio will use Conf.Root.dbRecovery instead
       implicit val errorRecovery: ErrorStrategiesRef = env.get[Conf.Root].alternateDbRecovery
-      Database.transactionOrWidenR[AppEnv](queries)
+      Database.transactionOrWidenR(queries)
     }
   }
 

--- a/src/samples/scala/samples/doobie/test/SomeTest.scala
+++ b/src/samples/scala/samples/doobie/test/SomeTest.scala
@@ -28,7 +28,7 @@ object SomeTest extends RunnableSpec[TestEnvironment with Database with PersonQu
 
   private val myTest = testM("some test on a method") {
     for {
-      h <- Database.transactionR[PersonQueries](PersonQueries.list)
+      h <- Database.transactionR(PersonQueries.list)
       // do something with that result
     } yield assert(h)(equalTo(Nil))
   }

--- a/src/test/scala/io/github/gaelrenoux/tranzactio/DatabaseOpsCompileTest.scala
+++ b/src/test/scala/io/github/gaelrenoux/tranzactio/DatabaseOpsCompileTest.scala
@@ -11,141 +11,222 @@ trait DatabaseOpsCompileTest {
 
   val serviceOperations: DatabaseOps.ServiceOps[Connection]
 
-  val serviceChecks: Unit = {
+  object ServicesCheck {
 
-    /* transactionR */
-    val _: ZIO[Environment, Either[DbException, String], Int] =
-      serviceOperations.transactionR[Environment](z[Connection with Environment, String])
-    val _: ZIO[Environment, Either[DbException, String], Int] =
-      serviceOperations.transactionR[Environment](z[Connection with Environment, String], commitOnFailure = true)
+    object TransactionR {
+      val a: ZIO[Environment, Either[DbException, String], Int] =
+        serviceOperations.transactionR(z[Connection with Environment, String])
+      val b: ZIO[Environment, Either[DbException, String], Int] =
+        serviceOperations.transactionR(z[Connection with Environment, String], commitOnFailure = true)
 
-    /* transaction */
-    val _: ZIO[Any, Either[DbException, String], Int] =
-      serviceOperations.transaction(z[Connection, String])
-    val _: ZIO[Any, Either[DbException, String], Int] =
-      serviceOperations.transaction(z[Connection, String], commitOnFailure = true)
+      @deprecated("", since="1.3.0") val aDeprecated: ZIO[Environment, Either[DbException, String], Int] =
+        serviceOperations.transactionR[Environment](z[Connection with Environment, String])
+      @deprecated("", since="1.3.0") val bDeprecated: ZIO[Environment, Either[DbException, String], Int] =
+        serviceOperations.transactionR[Environment](z[Connection with Environment, String], commitOnFailure = true)
+    }
 
-    /* transactionOrWidenR */
-    val _: ZIO[Environment, Exception, Int] =
-      serviceOperations.transactionOrWidenR[Environment](z[Connection with Environment, IllegalArgumentException])
-    val _: ZIO[Environment, DbException, Int] =
-      serviceOperations.transactionOrWidenR[Environment](z[Connection with Environment, DbException])
-    val _: ZIO[Environment, Exception, Int] =
-      serviceOperations.transactionOrWidenR[Environment](z[Connection with Environment, IllegalArgumentException], commitOnFailure = true)
-    val _: ZIO[Environment, DbException, Int] =
-      serviceOperations.transactionOrWidenR[Environment](z[Connection with Environment, DbException], commitOnFailure = true)
+    object Transaction {
+      val a: ZIO[Any, Either[DbException, String], Int] =
+        serviceOperations.transaction(z[Connection, String])
+      val b: ZIO[Any, Either[DbException, String], Int] =
+        serviceOperations.transaction(z[Connection, String], commitOnFailure = true)
+    }
 
-    /* transactionOrWiden */
-    val _: ZIO[Any, Exception, Int] =
-      serviceOperations.transactionOrWiden(z[Connection, IllegalArgumentException])
-    val _: ZIO[Any, DbException, Int] =
-      serviceOperations.transactionOrWiden(z[Connection, DbException])
-    val _: ZIO[Any, Exception, Int] =
-      serviceOperations.transactionOrWiden(z[Connection, IllegalArgumentException], commitOnFailure = true)
-    val _: ZIO[Any, DbException, Int] =
-      serviceOperations.transactionOrWiden(z[Connection, DbException], commitOnFailure = true)
+    object TransactionOrWidenR {
+      val a: ZIO[Environment, Exception, Int] =
+        serviceOperations.transactionOrWidenR(z[Connection with Environment, IllegalArgumentException])
+      val b: ZIO[Environment, DbException, Int] =
+        serviceOperations.transactionOrWidenR(z[Connection with Environment, DbException])
+      val c: ZIO[Environment, Exception, Int] =
+        serviceOperations.transactionOrWidenR(z[Connection with Environment, IllegalArgumentException], commitOnFailure = true)
+      val d: ZIO[Environment, DbException, Int] =
+        serviceOperations.transactionOrWidenR(z[Connection with Environment, DbException], commitOnFailure = true)
 
-    /* transactionOrDieR (specifying remainder) */
-    val _: ZIO[Environment, String, Int] =
-      serviceOperations.transactionOrDieR[Environment](z[Connection with Environment, String])
-    val _: ZIO[Environment, String, Int] =
-      serviceOperations.transactionOrDieR[Environment](z[Connection with Environment, String], commitOnFailure = true)
-    val _: ZIO[Environment, String, Int] =
-      serviceOperations.transactionOrDieR[Environment](z[Connection with Environment, String], commitOnFailure = true)
+      @deprecated("", since="1.3.0") val aDeprecated: ZIO[Environment, Exception, Int] =
+        serviceOperations.transactionOrWidenR[Environment](z[Connection with Environment, IllegalArgumentException])
+      @deprecated("", since="1.3.0") val bDeprecated: ZIO[Environment, DbException, Int] =
+        serviceOperations.transactionOrWidenR[Environment](z[Connection with Environment, DbException])
+      @deprecated("", since="1.3.0") val cDeprecated: ZIO[Environment, Exception, Int] =
+        serviceOperations.transactionOrWidenR[Environment](z[Connection with Environment, IllegalArgumentException], commitOnFailure = true)
+      @deprecated("", since="1.3.0") val dDeprecated: ZIO[Environment, DbException, Int] =
+        serviceOperations.transactionOrWidenR[Environment](z[Connection with Environment, DbException], commitOnFailure = true)
+    }
 
-    /* transactionOrDieR (without specifying remainder) */
-    val _: ZIO[Environment, String, Int] =
-      serviceOperations.transactionOrDieR(z[Connection with Environment, String])
-    val _: ZIO[Environment, String, Int] =
-      serviceOperations.transactionOrDieR(z[Connection with Environment, String], commitOnFailure = true)
-    val _: ZIO[Environment, String, Int] =
-      serviceOperations.transactionOrDieR(z[Connection with Environment, String], commitOnFailure = true)
+    object TransactionOrWiden {
+      val a: ZIO[Any, Exception, Int] =
+        serviceOperations.transactionOrWiden(z[Connection, IllegalArgumentException])
+      val b: ZIO[Any, DbException, Int] =
+        serviceOperations.transactionOrWiden(z[Connection, DbException])
+      val c: ZIO[Any, Exception, Int] =
+        serviceOperations.transactionOrWiden(z[Connection, IllegalArgumentException], commitOnFailure = true)
+      val d: ZIO[Any, DbException, Int] =
+        serviceOperations.transactionOrWiden(z[Connection, DbException], commitOnFailure = true)
+    }
 
-    /* transactionOrDie */
-    val _: ZIO[Any, String, Int] =
-      serviceOperations.transactionOrDie(z[Connection, String])
-    val _: ZIO[Any, String, Int] =
-      serviceOperations.transactionOrDie(z[Connection, String], commitOnFailure = true)
+    object TransactionOrDieR {
+      val a: ZIO[Environment, String, Int] =
+        serviceOperations.transactionOrDieR(z[Connection with Environment, String])
+      val b: ZIO[Environment, String, Int] =
+        serviceOperations.transactionOrDieR(z[Connection with Environment, String], commitOnFailure = true)
+      val c: ZIO[Environment, String, Int] =
+        serviceOperations.transactionOrDieR(z[Connection with Environment, String], commitOnFailure = true)
 
-    /* autoCommitR */
-    val _: ZIO[Environment, Either[DbException, String], Int] =
-      serviceOperations.autoCommitR[Environment](z[Connection with Environment, String])
+      @deprecated("", since="1.3.0") val aDeprecated: ZIO[Environment, String, Int] =
+        serviceOperations.transactionOrDieR[Environment](z[Connection with Environment, String])
+      @deprecated("", since="1.3.0") val bDeprecated: ZIO[Environment, String, Int] =
+        serviceOperations.transactionOrDieR[Environment](z[Connection with Environment, String], commitOnFailure = true)
+      @deprecated("", since="1.3.0") val cDeprecated: ZIO[Environment, String, Int] =
+        serviceOperations.transactionOrDieR[Environment](z[Connection with Environment, String], commitOnFailure = true)
+    }
 
-    /* autoCommit */
-    val _: ZIO[Any, Either[DbException, String], Int] =
-      serviceOperations.autoCommit(z[Connection, String])
+    object TransactionOrDie {
+      val a: ZIO[Any, String, Int] =
+        serviceOperations.transactionOrDie(z[Connection, String])
+      val b: ZIO[Any, String, Int] =
+        serviceOperations.transactionOrDie(z[Connection, String], commitOnFailure = true)
+    }
 
-    /* autoCommitOrWidenR (specifying remainder)*/
-    val _: ZIO[Environment, Exception, Int] =
-      serviceOperations.autoCommitOrWidenR[Environment](z[Connection with Environment, IllegalArgumentException])
-    val _: ZIO[Environment, DbException, Int] =
-      serviceOperations.autoCommitOrWidenR[Environment](z[Connection with Environment, DbException])
+    object AutoCommitR {
+      val a: ZIO[Environment, Either[DbException, String], Int] =
+        serviceOperations.autoCommitR(z[Connection with Environment, String])
 
-    /* autoCommitOrWidenR (without specifying remainder)*/
-    val _: ZIO[Environment, Exception, Int] =
-      serviceOperations.autoCommitOrWidenR(z[Connection with Environment, IllegalArgumentException])
-    val c: ZIO[Environment, DbException, Int] =
-      serviceOperations.autoCommitOrWidenR(z[Connection with Environment, DbException])
+      @deprecated("", since="1.3.0") val aDeprecated: ZIO[Environment, Either[DbException, String], Int] =
+        serviceOperations.autoCommitR[Environment](z[Connection with Environment, String])
+    }
 
-    /* autoCommitOrWiden */
-    val _: ZIO[Any, Exception, Int] =
-      serviceOperations.autoCommitOrWiden(z[Connection, IllegalArgumentException])
-    val _: ZIO[Any, DbException, Int] =
-      serviceOperations.autoCommitOrWiden(z[Connection, DbException])
+    object AutoCommit {
+      val a: ZIO[Any, Either[DbException, String], Int] =
+        serviceOperations.autoCommit(z[Connection, String])
+    }
 
-    /* autoCommitOrDieR */
-    val _: ZIO[Environment, String, Int] =
-      serviceOperations.autoCommitOrDieR[Environment](z[Connection with Environment, String])
+    object AutoCommitOrWidenR {
+      val a: ZIO[Environment, Exception, Int] =
+        serviceOperations.autoCommitOrWidenR(z[Connection with Environment, IllegalArgumentException])
+      val b: ZIO[Environment, DbException, Int] =
+        serviceOperations.autoCommitOrWidenR(z[Connection with Environment, DbException])
 
-    /* autoCommitOrDie */
-    val _: ZIO[Any, String, Int] =
-      serviceOperations.autoCommitOrDie(z[Connection, String])
+      @deprecated("", since="1.3.0") val aDeprecated: ZIO[Environment, Exception, Int] =
+        serviceOperations.autoCommitOrWidenR[Environment](z[Connection with Environment, IllegalArgumentException])
+      @deprecated("", since="1.3.0") val bDeprecated: ZIO[Environment, DbException, Int] =
+        serviceOperations.autoCommitOrWidenR[Environment](z[Connection with Environment, DbException])
+    }
+
+    object AutoCommitOrWiden {
+      val a: ZIO[Any, Exception, Int] =
+        serviceOperations.autoCommitOrWiden(z[Connection, IllegalArgumentException])
+      val b: ZIO[Any, DbException, Int] =
+        serviceOperations.autoCommitOrWiden(z[Connection, DbException])
+    }
+
+    object AutoCommitOrDieR {
+      val a: ZIO[Environment, String, Int] =
+        serviceOperations.autoCommitOrDieR(z[Connection with Environment, String])
+
+      @deprecated("", since="1.3.0") val aDeprecated: ZIO[Environment, String, Int] =
+        serviceOperations.autoCommitOrDieR[Environment](z[Connection with Environment, String])
+    }
+
+    object AutoCommitOrDie {
+      val a: ZIO[Any, String, Int] =
+        serviceOperations.autoCommitOrDie(z[Connection, String])
+    }
+
   }
 
 
   val moduleOperations: DatabaseOps.ModuleOps[Connection, DatabaseService]
 
-  val moduleChecks: Unit = {
+  object ModuleCheck {
 
-    /* transaction */
-    val _: ZIO[Database with Environment, Either[DbException, String], Int] =
-      moduleOperations.transactionR[Environment](z[Connection with Environment, String])
-    val _: ZIO[Database, Either[DbException, String], Int] =
-      moduleOperations.transaction(z[Connection, String])
+    object TransactionR {
+      val a: ZIO[Database with Environment, Either[DbException, String], Int] =
+        moduleOperations.transactionR(z[Connection with Environment, String])
+      @deprecated("", since="1.3.0") val aDeprecated: ZIO[Database with Environment, Either[DbException, String], Int] =
+        moduleOperations.transactionR[Environment](z[Connection with Environment, String])
+    }
 
-    val _: ZIO[Database with Environment, Exception, Int] =
-      moduleOperations.transactionOrWidenR[Environment](z[Connection with Environment, IllegalArgumentException])
-    val _: ZIO[Database with Environment, DbException, Int] =
-      moduleOperations.transactionOrWidenR[Environment](z[Connection with Environment, DbException])
-    val _: ZIO[Database, Exception, Int] =
-      moduleOperations.transactionOrWiden(z[Connection, IllegalArgumentException])
-    val _: ZIO[Database, DbException, Int] =
-      moduleOperations.transactionOrWiden(z[Connection, DbException])
+    object Transaction {
+      val a: ZIO[Database, Either[DbException, String], Int] =
+        moduleOperations.transaction(z[Connection, String])
+    }
 
-    val _: ZIO[Database with Environment, String, Int] =
-      moduleOperations.transactionOrDieR(z[Connection with Environment, String])
-    val _: ZIO[Database, String, Int] =
-      moduleOperations.transactionOrDie[String, Int](z[Connection, String])
+    object TransactionOrWidenR {
+      val a: ZIO[Database with Environment, Exception, Int] =
+        moduleOperations.transactionOrWidenR(z[Connection with Environment, IllegalArgumentException])
+      val b: ZIO[Database with Environment, DbException, Int] =
+        moduleOperations.transactionOrWidenR(z[Connection with Environment, DbException])
 
-    /* auto-commit */
-    val _: ZIO[Database with Environment, Either[DbException, String], Int] =
-      moduleOperations.autoCommitR[Environment](z[Connection with Environment, String])
-    val _: ZIO[Database, Either[DbException, String], Int] =
-      moduleOperations.autoCommit(z[Connection, String])
+      @deprecated("", since="1.3.0") val aDeprecated: ZIO[Database with Environment, Exception, Int] =
+        moduleOperations.transactionOrWidenR[Environment](z[Connection with Environment, IllegalArgumentException])
+      @deprecated("", since="1.3.0") val bDeprecated: ZIO[Database with Environment, DbException, Int] =
+        moduleOperations.transactionOrWidenR[Environment](z[Connection with Environment, DbException])
+    }
 
-    val _: ZIO[Database with Environment, Exception, Int] =
-      moduleOperations.autoCommitOrWidenR[Environment](z[Connection with Environment, IllegalArgumentException])
-    val _: ZIO[Database with Environment, DbException, Int] =
-      moduleOperations.autoCommitOrWidenR[Environment](z[Connection with Environment, DbException])
-    val _: ZIO[Database, Exception, Int] =
-      moduleOperations.autoCommitOrWiden[Exception, Int](z[Connection, IllegalArgumentException])
-    val _: ZIO[Database, DbException, Int] =
-      moduleOperations.autoCommitOrWiden[DbException, Int](z[Connection, DbException])
+    object TransactionOrWiden {
+      val a: ZIO[Database, Exception, Int] =
+        moduleOperations.transactionOrWiden(z[Connection, IllegalArgumentException])
+      val b: ZIO[Database, DbException, Int] =
+        moduleOperations.transactionOrWiden(z[Connection, DbException])
+    }
 
-    val _: ZIO[Database with Environment, String, Int] =
-      moduleOperations.autoCommitOrDieR[Environment](z[Connection with Environment, String])
-    val _: ZIO[Database, String, Int] =
-      moduleOperations.autoCommitOrDie[String, Int](z[Connection, String])
+    object TransactionOrDieR {
+      val a: ZIO[Database with Environment, String, Int] =
+        moduleOperations.transactionOrDieR(z[Connection with Environment, String])
+
+      @deprecated("", since="1.3.0") val aDeprecated: ZIO[Database with Environment, String, Int] =
+        moduleOperations.transactionOrDieR[Environment](z[Connection with Environment, String])
+    }
+
+    object TransactionOrDie {
+      val a: ZIO[Database, String, Int] =
+        moduleOperations.transactionOrDie[String, Int](z[Connection, String])
+    }
+
+    object AutoCommitR {
+      val a: ZIO[Database with Environment, Either[DbException, String], Int] =
+        moduleOperations.autoCommitR(z[Connection with Environment, String])
+
+      @deprecated("", since="1.3.0") val aDeprecated: ZIO[Database with Environment, Either[DbException, String], Int] =
+        moduleOperations.autoCommitR[Environment](z[Connection with Environment, String])
+    }
+
+    object AutoCommit {
+      val a: ZIO[Database, Either[DbException, String], Int] =
+        moduleOperations.autoCommit(z[Connection, String])
+    }
+
+    object AutoCommitOrWidenR {
+      val a: ZIO[Database with Environment, Exception, Int] =
+        moduleOperations.autoCommitOrWidenR(z[Connection with Environment, IllegalArgumentException])
+      val b: ZIO[Database with Environment, DbException, Int] =
+        moduleOperations.autoCommitOrWidenR(z[Connection with Environment, DbException])
+
+      @deprecated("", since="1.3.0") val aDeprecated: ZIO[Database with Environment, Exception, Int] =
+        moduleOperations.autoCommitOrWidenR[Environment](z[Connection with Environment, IllegalArgumentException])
+      @deprecated("", since="1.3.0") val bDeprecated: ZIO[Database with Environment, DbException, Int] =
+        moduleOperations.autoCommitOrWidenR[Environment](z[Connection with Environment, DbException])
+    }
+
+    object AutoCommitOrWiden {
+      val a: ZIO[Database, Exception, Int] =
+        moduleOperations.autoCommitOrWiden[Exception, Int](z[Connection, IllegalArgumentException])
+      val b: ZIO[Database, DbException, Int] =
+        moduleOperations.autoCommitOrWiden[DbException, Int](z[Connection, DbException])
+    }
+
+    object AutoCommitOrDieR {
+      val a: ZIO[Database with Environment, String, Int] =
+        moduleOperations.autoCommitOrDieR(z[Connection with Environment, String])
+
+      @deprecated("", since="1.3.0") val aDeprecated: ZIO[Database with Environment, String, Int] =
+        moduleOperations.autoCommitOrDieR[Environment](z[Connection with Environment, String])
+    }
+
+    object AutoCommitOrDie {
+      val a: ZIO[Database, String, Int] =
+        moduleOperations.autoCommitOrDie[String, Int](z[Connection, String])
+    }
+
   }
 
 }

--- a/src/test/scala/io/github/gaelrenoux/tranzactio/DatabaseOpsCompileTest.scala
+++ b/src/test/scala/io/github/gaelrenoux/tranzactio/DatabaseOpsCompileTest.scala
@@ -45,11 +45,21 @@ trait DatabaseOpsCompileTest {
     val _: ZIO[Any, DbException, Int] =
       serviceOperations.transactionOrWiden(z[Connection, DbException], commitOnFailure = true)
 
-    /* transactionOrDieR */
+    /* transactionOrDieR (specifying remainder) */
     val _: ZIO[Environment, String, Int] =
       serviceOperations.transactionOrDieR[Environment](z[Connection with Environment, String])
     val _: ZIO[Environment, String, Int] =
       serviceOperations.transactionOrDieR[Environment](z[Connection with Environment, String], commitOnFailure = true)
+    val _: ZIO[Environment, String, Int] =
+      serviceOperations.transactionOrDieR[Environment](z[Connection with Environment, String], commitOnFailure = true)
+
+    /* transactionOrDieR (without specifying remainder) */
+    val _: ZIO[Environment, String, Int] =
+      serviceOperations.transactionOrDieR(z[Connection with Environment, String])
+    val _: ZIO[Environment, String, Int] =
+      serviceOperations.transactionOrDieR(z[Connection with Environment, String], commitOnFailure = true)
+    val _: ZIO[Environment, String, Int] =
+      serviceOperations.transactionOrDieR(z[Connection with Environment, String], commitOnFailure = true)
 
     /* transactionOrDie */
     val _: ZIO[Any, String, Int] =
@@ -65,11 +75,17 @@ trait DatabaseOpsCompileTest {
     val _: ZIO[Any, Either[DbException, String], Int] =
       serviceOperations.autoCommit(z[Connection, String])
 
-    /* autoCommitOrWidenR */
+    /* autoCommitOrWidenR (specifying remainder)*/
     val _: ZIO[Environment, Exception, Int] =
       serviceOperations.autoCommitOrWidenR[Environment](z[Connection with Environment, IllegalArgumentException])
     val _: ZIO[Environment, DbException, Int] =
       serviceOperations.autoCommitOrWidenR[Environment](z[Connection with Environment, DbException])
+
+    /* autoCommitOrWidenR (without specifying remainder)*/
+    val _: ZIO[Environment, Exception, Int] =
+      serviceOperations.autoCommitOrWidenR(z[Connection with Environment, IllegalArgumentException])
+    val c: ZIO[Environment, DbException, Int] =
+      serviceOperations.autoCommitOrWidenR(z[Connection with Environment, DbException])
 
     /* autoCommitOrWiden */
     val _: ZIO[Any, Exception, Int] =
@@ -107,7 +123,7 @@ trait DatabaseOpsCompileTest {
       moduleOperations.transactionOrWiden(z[Connection, DbException])
 
     val _: ZIO[Database with Environment, String, Int] =
-      moduleOperations.transactionOrDieR[Environment](z[Connection with Environment, String])
+      moduleOperations.transactionOrDieR(z[Connection with Environment, String])
     val _: ZIO[Database, String, Int] =
       moduleOperations.transactionOrDie[String, Int](z[Connection, String])
 

--- a/src/test/scala/io/github/gaelrenoux/tranzactio/integration/AnormIT.scala
+++ b/src/test/scala/io/github/gaelrenoux/tranzactio/integration/AnormIT.scala
@@ -35,72 +35,72 @@ object AnormIT extends ITSpec[Database, PersonQueries] {
 
   private val testDataCommittedOnTransactionSuccess = testM("data committed on transaction success") {
     for {
-      _ <- Database.transactionR[PersonQueries](PersonQueries.setup)
-      _ <- Database.transactionR[PersonQueries](PersonQueries.insert(buffy))
-      persons <- Database.transactionR[PersonQueries](PersonQueries.list)
+      _ <- Database.transactionR(PersonQueries.setup)
+      _ <- Database.transactionR(PersonQueries.insert(buffy))
+      persons <- Database.transactionR(PersonQueries.list)
     } yield assert(persons)(equalTo(List(buffy)))
   }
 
   private val testConnectionClosedOnTransactionSuccess = testM("connection closed on transaction success") {
     for {
-      _ <- Database.transactionR[PersonQueries](PersonQueries.setup)
-      _ <- Database.transactionR[PersonQueries](PersonQueries.insert(buffy))
+      _ <- Database.transactionR(PersonQueries.setup)
+      _ <- Database.transactionR(PersonQueries.insert(buffy))
       connectionCount <- Database.transaction(connectionCountQuery)
     } yield assert(connectionCount)(equalTo(1)) // only the current connection
   }
 
   private val testDataRollbackedOnTransactionFailure = testM("data rollbacked on transaction failure if commitOnFailure=false") {
     for {
-      _ <- Database.transactionR[PersonQueries](PersonQueries.setup)
-      _ <- Database.transactionR[PersonQueries](PersonQueries.insert(buffy) &&& PersonQueries.failing).flip
-      persons <- Database.transactionR[PersonQueries](PersonQueries.list)
+      _ <- Database.transactionR(PersonQueries.setup)
+      _ <- Database.transactionR(PersonQueries.insert(buffy) &&& PersonQueries.failing).flip
+      persons <- Database.transactionR(PersonQueries.list)
     } yield assert(persons)(equalTo(Nil))
   }
 
   private val testDataCommittedOnTransactionFailure = testM("data committed on transaction failure if commitOnFailure=true") {
     for {
-      _ <- Database.transactionR[PersonQueries](PersonQueries.setup)
-      _ <- Database.transactionR[PersonQueries](PersonQueries.insert(buffy) &&& PersonQueries.failing, commitOnFailure = true).flip
-      persons <- Database.transactionR[PersonQueries](PersonQueries.list)
+      _ <- Database.transactionR(PersonQueries.setup)
+      _ <- Database.transactionR(PersonQueries.insert(buffy) &&& PersonQueries.failing, commitOnFailure = true).flip
+      persons <- Database.transactionR(PersonQueries.list)
     } yield assert(persons)(equalTo(List(buffy)))
   }
 
   private val testConnectionClosedOnTransactionFailure = testM("connection closed on transaction failure") {
     for {
-      _ <- Database.transactionR[PersonQueries](PersonQueries.setup)
-      _ <- Database.transactionR[PersonQueries](PersonQueries.insert(buffy) &&& PersonQueries.failing).flip
+      _ <- Database.transactionR(PersonQueries.setup)
+      _ <- Database.transactionR(PersonQueries.insert(buffy) &&& PersonQueries.failing).flip
       connectionCount <- Database.transaction(connectionCountQuery)
     } yield assert(connectionCount)(equalTo(1)) // only the current connection
   }
 
   private val testDataCommittedOnAutoCommitSuccess = testM("data committed on autoCommit success") {
     for {
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.setup)
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.insert(buffy))
-      persons <- Database.autoCommitR[PersonQueries](PersonQueries.list)
+      _ <- Database.autoCommitR(PersonQueries.setup)
+      _ <- Database.autoCommitR(PersonQueries.insert(buffy))
+      persons <- Database.autoCommitR(PersonQueries.list)
     } yield assert(persons)(equalTo(List(buffy)))
   }
 
   private val testConnectionClosedOnAutoCommitSuccess = testM("connection closed on autoCommit success") {
     for {
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.setup)
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.insert(buffy))
+      _ <- Database.autoCommitR(PersonQueries.setup)
+      _ <- Database.autoCommitR(PersonQueries.insert(buffy))
       connectionCount <- Database.autoCommit(connectionCountQuery)
     } yield assert(connectionCount)(equalTo(1)) // only the current connection
   }
 
   private val testDataRollbackedOnAutoCommitFailure = testM("data rollbacked on autoCommit failure") {
     for {
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.setup)
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.insert(buffy) &&& PersonQueries.failing).flip
-      persons <- Database.autoCommitR[PersonQueries](PersonQueries.list)
+      _ <- Database.autoCommitR(PersonQueries.setup)
+      _ <- Database.autoCommitR(PersonQueries.insert(buffy) &&& PersonQueries.failing).flip
+      persons <- Database.autoCommitR(PersonQueries.list)
     } yield assert(persons)(equalTo(List(buffy)))
   }
 
   private val testConnectionClosedOnAutoCommitFailure = testM("connection closed on autoCommit failure") {
     for {
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.setup)
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.insert(buffy))
+      _ <- Database.autoCommitR(PersonQueries.setup)
+      _ <- Database.autoCommitR(PersonQueries.insert(buffy))
       connectionCount <- Database.autoCommit(connectionCountQuery)
     } yield assert(connectionCount)(equalTo(1)) // only the current connection
   }

--- a/src/test/scala/io/github/gaelrenoux/tranzactio/integration/DoobieIT.scala
+++ b/src/test/scala/io/github/gaelrenoux/tranzactio/integration/DoobieIT.scala
@@ -39,81 +39,81 @@ object DoobieIT extends ITSpec[Database, PersonQueries] {
 
   private val testDataCommittedOnTransactionSuccess = testM("data committed on transaction success") {
     for {
-      _ <- Database.transactionR[PersonQueries](PersonQueries.setup)
-      _ <- Database.transactionR[PersonQueries](PersonQueries.insert(buffy))
-      persons <- Database.transactionR[PersonQueries](PersonQueries.list)
+      _ <- Database.transactionR(PersonQueries.setup)
+      _ <- Database.transactionR(PersonQueries.insert(buffy))
+      persons <- Database.transactionR(PersonQueries.list)
     } yield assert(persons)(equalTo(List(buffy)))
   }
 
   private val testConnectionClosedOnTransactionSuccess = testM("connection closed on transaction success") {
     for {
-      _ <- Database.transactionR[PersonQueries](PersonQueries.setup)
-      _ <- Database.transactionR[PersonQueries](PersonQueries.insert(buffy))
+      _ <- Database.transactionR(PersonQueries.setup)
+      _ <- Database.transactionR(PersonQueries.insert(buffy))
       connectionCount <- Database.transaction(connectionCountQuery)
     } yield assert(connectionCount)(equalTo(1)) // only the current connection
   }
 
   private val testDataRollbackedOnTransactionFailure = testM("data rollbacked on transaction failure if commitOnFailure=false") {
     for {
-      _ <- Database.transactionR[PersonQueries](PersonQueries.setup)
-      _ <- Database.transactionR[PersonQueries](PersonQueries.insert(buffy) &&& PersonQueries.failing).flip
-      persons <- Database.transactionR[PersonQueries](PersonQueries.list)
+      _ <- Database.transactionR(PersonQueries.setup)
+      _ <- Database.transactionR(PersonQueries.insert(buffy) &&& PersonQueries.failing).flip
+      persons <- Database.transactionR(PersonQueries.list)
     } yield assert(persons)(equalTo(Nil))
   }
 
   private val testDataCommittedOnTransactionFailure = testM("data committed on transaction failure if commitOnFailure=true") {
     for {
-      _ <- Database.transactionR[PersonQueries](PersonQueries.setup)
-      _ <- Database.transactionR[PersonQueries](PersonQueries.insert(buffy) &&& PersonQueries.failing, commitOnFailure = true).flip
-      persons <- Database.transactionR[PersonQueries](PersonQueries.list)
+      _ <- Database.transactionR(PersonQueries.setup)
+      _ <- Database.transactionR(PersonQueries.insert(buffy) &&& PersonQueries.failing, commitOnFailure = true).flip
+      persons <- Database.transactionR(PersonQueries.list)
     } yield assert(persons)(equalTo(List(buffy)))
   }
 
   private val testConnectionClosedOnTransactionFailure = testM("connection closed on transaction failure") {
     for {
-      _ <- Database.transactionR[PersonQueries](PersonQueries.setup)
-      _ <- Database.transactionR[PersonQueries](PersonQueries.insert(buffy) &&& PersonQueries.failing).flip
+      _ <- Database.transactionR(PersonQueries.setup)
+      _ <- Database.transactionR(PersonQueries.insert(buffy) &&& PersonQueries.failing).flip
       connectionCount <- Database.transaction(connectionCountQuery)
     } yield assert(connectionCount)(equalTo(1)) // only the current connection
   }
 
   private val testDataCommittedOnAutoCommitSuccess = testM("data committed on autoCommit success") {
     for {
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.setup)
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.insert(buffy))
-      persons <- Database.autoCommitR[PersonQueries](PersonQueries.list)
+      _ <- Database.autoCommitR(PersonQueries.setup)
+      _ <- Database.autoCommitR(PersonQueries.insert(buffy))
+      persons <- Database.autoCommitR(PersonQueries.list)
     } yield assert(persons)(equalTo(List(buffy)))
   }
 
   private val testConnectionClosedOnAutoCommitSuccess = testM("connection closed on autoCommit success") {
     for {
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.setup)
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.insert(buffy))
+      _ <- Database.autoCommitR(PersonQueries.setup)
+      _ <- Database.autoCommitR(PersonQueries.insert(buffy))
       connectionCount <- Database.autoCommit(connectionCountQuery)
     } yield assert(connectionCount)(equalTo(1)) // only the current connection
   }
 
   private val testDataRollbackedOnAutoCommitFailure = testM("data rollbacked on autoCommit failure") {
     for {
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.setup)
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.insert(buffy) &&& PersonQueries.failing).flip
-      persons <- Database.autoCommitR[PersonQueries](PersonQueries.list)
+      _ <- Database.autoCommitR(PersonQueries.setup)
+      _ <- Database.autoCommitR(PersonQueries.insert(buffy) &&& PersonQueries.failing).flip
+      persons <- Database.autoCommitR(PersonQueries.list)
     } yield assert(persons)(equalTo(List(buffy)))
   }
 
   private val testConnectionClosedOnAutoCommitFailure = testM("connection closed on autoCommit failure") {
     for {
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.setup)
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.insert(buffy))
+      _ <- Database.autoCommitR(PersonQueries.setup)
+      _ <- Database.autoCommitR(PersonQueries.insert(buffy))
       connectionCount <- Database.autoCommit(connectionCountQuery)
     } yield assert(connectionCount)(equalTo(1)) // only the current connection
   }
 
   private val testStreamDoesNotLoadAllValues = testM("stream does not load all values") {
     for {
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.setup)
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.insert(buffy))
-      _ <- Database.autoCommitR[PersonQueries](PersonQueries.insert(giles))
+      _ <- Database.autoCommitR(PersonQueries.setup)
+      _ <- Database.autoCommitR(PersonQueries.insert(buffy))
+      _ <- Database.autoCommitR(PersonQueries.insert(giles))
       result <- Database.autoCommit {
         val doobieStream = sql"""SELECT given_name, family_name FROM person""".query[Person]
           .streamWithChunkSize(1) // make sure it's read one by one


### PR DESCRIPTION
OK, I've taken @kitlangton's proposal from https://github.com/gaelrenoux/tranzactio/pull/23 and applied it to all *R methods. And behold: no more explicit environment declared when calling those methods! See discussion on that PR for details.

Also fixes the compile test that were not breaking compilation when they should.