### PR TITLE
Introduces DbContext to allow migration to Doobie-RC4

### DIFF
--- a/anorm/src/main/scala/io/github/gaelrenoux/tranzactio/anorm/package.scala
+++ b/anorm/src/main/scala/io/github/gaelrenoux/tranzactio/anorm/package.scala
@@ -17,11 +17,6 @@ package object anorm extends Wrapper {
 
   private[tranzactio] val connectionTag = implicitly[Tag[Connection]]
 
-  /** How to provide a Connection for the module, given a JDBC connection and some environment. */
-  private final def connectionFromJdbc(connection: => JdbcConnection)(implicit trace: Trace): ZIO[Any, Nothing, Connection] = {
-    ZIO.succeed(connection)
-  }
-
   override final def tzio[A](q: => Query[A])(implicit trace: Trace): TranzactIO[A] =
     ZIO.serviceWithZIO[Connection] { c =>
       attemptBlocking(q(c))
@@ -44,6 +39,6 @@ package object anorm extends Wrapper {
 
   private class DatabaseService(cs: ConnectionSource) extends DatabaseServiceBase[Connection](cs) {
     override final def connectionFromJdbc(connection: => JdbcConnection)(implicit trace: Trace): ZIO[Any, Nothing, Connection] =
-      anorm.connectionFromJdbc(connection)
+      ZIO.succeed(connection)
   }
 }

--- a/core/src/main/scala/io/github/gaelrenoux/tranzactio/DatabaseModuleBase.scala
+++ b/core/src/main/scala/io/github/gaelrenoux/tranzactio/DatabaseModuleBase.scala
@@ -1,13 +1,12 @@
 package io.github.gaelrenoux.tranzactio
 
 
-import zio.{Tag, ZIO, ZLayer, Trace}
+import zio.{Tag, Trace, ZIO, ZLayer}
 
-import java.sql.{Connection => JdbcConnection}
 import javax.sql.DataSource
 
 /** Template implementing the commodity methods for a Db module. */
-abstract class DatabaseModuleBase[Connection, Database <: DatabaseOps.ServiceOps[Connection] : Tag]
+abstract class DatabaseModuleBase[Connection, Database <: DatabaseOps.ServiceOps[Connection] : Tag, DbContext]
   extends DatabaseOps.ModuleOps[Connection, Database] {
 
   type Service = DatabaseOps.ServiceOps[Connection]
@@ -24,32 +23,29 @@ abstract class DatabaseModuleBase[Connection, Database <: DatabaseOps.ServiceOps
   override def autoCommit[R, E, A](
       zio: => ZIO[Connection with R, E, A]
   )(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent, trace: Trace): ZIO[Database with R, Either[DbException, E], A] = {
-    ZIO.serviceWithZIO[Database]{ db=>
+    ZIO.serviceWithZIO[Database] { db =>
       db.autoCommit[R, E, A](zio)
     }
   }
 
   /** Creates a Database Layer which requires an existing ConnectionSource. */
-  def fromConnectionSource(implicit trace: Trace): ZLayer[ConnectionSource, Nothing, Database]
-
-  /** Creates a Tranzactio Connection, given a JDBC connection and a Blocking. Useful for some utilities. */
-  def connectionFromJdbc(connection: => JdbcConnection)(implicit trace: Trace): ZIO[Any, Nothing, Connection]
+  def fromConnectionSource(implicit dbContext: DbContext, trace: Trace): ZLayer[ConnectionSource, Nothing, Database]
 
   /** Commodity method: creates a Database Layer which includes its own ConnectionSource based on a DataSource. Most
    * connection pool implementations should be able to provide you a DataSource.
    *
    * When no implicit ErrorStrategies is available, the default ErrorStrategies will be used.
    */
-  final def fromDatasource(implicit trace: Trace): ZLayer[DataSource, Nothing, Database] =
+  final def fromDatasource(implicit dbContext: DbContext, trace: Trace): ZLayer[DataSource, Nothing, Database] =
     ConnectionSource.fromDatasource >>> fromConnectionSource
 
   /** As `fromDatasource`, but provides a default ErrorStrategiesRef. When a method is called with no available implicit
    * ErrorStrategiesRef, the ErrorStrategiesRef in argument will be used. */
-  final def fromDatasource(errorStrategies: ErrorStrategiesRef)(implicit trace: Trace): ZLayer[DataSource, Nothing, Database] =
+  final def fromDatasource(errorStrategies: ErrorStrategiesRef)(implicit dbContext: DbContext, trace: Trace): ZLayer[DataSource, Nothing, Database] =
     ConnectionSource.fromDatasource(errorStrategies) >>> fromConnectionSource
 
   /** As `fromDatasource(ErrorStrategiesRef)`, but an `ErrorStrategies` is provided through a layer instead of as a parameter. */
-  final def fromDatasourceAndErrorStrategies(implicit trace: Trace): ZLayer[DataSource with ErrorStrategies, Nothing, Database] =
+  final def fromDatasourceAndErrorStrategies(implicit dbContext: DbContext, trace: Trace): ZLayer[DataSource with ErrorStrategies, Nothing, Database] =
     ConnectionSource.fromDatasourceAndErrorStrategies >>> fromConnectionSource
 
 }

--- a/core/src/main/scala/io/github/gaelrenoux/tranzactio/EmptyDbContext.scala
+++ b/core/src/main/scala/io/github/gaelrenoux/tranzactio/EmptyDbContext.scala
@@ -1,0 +1,6 @@
+package io.github.gaelrenoux.tranzactio
+
+/** To be used by libraries where a DbContext is not necessary */
+object EmptyDbContext {
+  implicit val Default: EmptyDbContext.type = EmptyDbContext
+}

--- a/core/src/main/scala/io/github/gaelrenoux/tranzactio/Wrapper.scala
+++ b/core/src/main/scala/io/github/gaelrenoux/tranzactio/Wrapper.scala
@@ -14,6 +14,9 @@ trait Wrapper {
 
   val Database: DatabaseOps.ModuleOps[Connection, _ <: DatabaseOps.ServiceOps[Connection]] // scalastyle:ignore field.name
 
+  /** Contextual information for the DB, its content depending on the underlying library. */
+  type DbContext
+
   /** The specific type used in the wrapped library to represent an SQL query. */
   type Query[A]
 

--- a/core/src/main/scala/io/github/gaelrenoux/tranzactio/test/DatabaseModuleTestOps.scala
+++ b/core/src/main/scala/io/github/gaelrenoux/tranzactio/test/DatabaseModuleTestOps.scala
@@ -4,7 +4,7 @@ import io.github.gaelrenoux.tranzactio._
 import zio.{Tag, ZEnvironment, ZIO, ZLayer, Trace}
 
 /** Testing utilities on the Database module. */
-trait DatabaseModuleTestOps[Connection] extends DatabaseModuleBase[Connection, DatabaseOps.ServiceOps[Connection]] {
+trait DatabaseModuleTestOps[Connection, DbContext] extends DatabaseModuleBase[Connection, DatabaseOps.ServiceOps[Connection], DbContext] {
 
   type AnyDatabase = DatabaseOps.ServiceOps[Connection]
 
@@ -12,7 +12,7 @@ trait DatabaseModuleTestOps[Connection] extends DatabaseModuleBase[Connection, D
 
   /** A Connection which is incapable of running anything, to use when unit testing (and the queries are actually stubbed,
    * so they do not need a Database). Trying to run actual queries against it will fail. */
-  def noConnection(implicit trace: Trace): ZIO[Any, Nothing, Connection] = connectionFromJdbc(NoopJdbcConnection)
+  def noConnection(implicit trace: Trace): ZIO[Any, Nothing, Connection]
 
   /** A Database which is incapable of running anything, to use when unit testing (and the queries are actually stubbed,
    * so they do not need a Database). Trying to run actual queries against it will fail. */

--- a/examples/src/test/scala/samples/anorm/LayeredApp.scala
+++ b/examples/src/test/scala/samples/anorm/LayeredApp.scala
@@ -4,7 +4,6 @@ import io.github.gaelrenoux.tranzactio.anorm._
 import io.github.gaelrenoux.tranzactio.{DbException, ErrorStrategiesRef}
 import samples.{Conf, ConnectionPool, Person}
 import zio._
-import zio.Console
 
 /** A sample app where all modules are linked through ZLayer. Should run as is (make sure you have com.h2database:h2 in
  * your dependencies). */

--- a/examples/src/test/scala/samples/doobie/LayeredApp.scala
+++ b/examples/src/test/scala/samples/doobie/LayeredApp.scala
@@ -14,8 +14,8 @@ object LayeredApp extends zio.ZIOAppDefault {
   private val conf = Conf.live("samble-doobie-app")
   private val dbRecoveryConf = conf >>> ZLayer.fromFunction((_: Conf).dbRecovery)
   private val datasource = conf >>> ConnectionPool.live
-  // The DoobieDbContext is optional, default is to have the noop LogHandler
-  implicit val doobieContext: DbContext = DbContext(logHandler = LogHandler.jdkLogHandler[Task])
+  // The DbContext is optional, default is to have the noop LogHandler
+  implicit val dbContext: DbContext = DbContext(logHandler = LogHandler.jdkLogHandler[Task])
   private val database = (datasource ++ dbRecoveryConf) >>> Database.fromDatasourceAndErrorStrategies
   private val personQueries = PersonQueries.live
 

--- a/examples/src/test/scala/samples/doobie/LayeredApp.scala
+++ b/examples/src/test/scala/samples/doobie/LayeredApp.scala
@@ -1,5 +1,7 @@
 package samples.doobie
 
+import zio.interop.catz._
+import doobie.util.log.LogHandler
 import io.github.gaelrenoux.tranzactio.doobie._
 import io.github.gaelrenoux.tranzactio.{DbException, ErrorStrategiesRef}
 import samples.{Conf, ConnectionPool, Person}
@@ -13,6 +15,8 @@ object LayeredApp extends zio.ZIOAppDefault {
   private val conf = Conf.live("samble-doobie-app")
   private val dbRecoveryConf = conf >>> ZLayer.fromFunction((_: Conf).dbRecovery)
   private val datasource = conf >>> ConnectionPool.live
+  // The DoobieDbContext is optional, default is to have the noop LogHandler
+  implicit val doobieContext: DbContext = DbContext(logHandler = LogHandler.jdkLogHandler[Task])
   private val database = (datasource ++ dbRecoveryConf) >>> Database.fromDatasourceAndErrorStrategies
   private val personQueries = PersonQueries.live
 

--- a/examples/src/test/scala/samples/doobie/LayeredApp.scala
+++ b/examples/src/test/scala/samples/doobie/LayeredApp.scala
@@ -1,12 +1,11 @@
 package samples.doobie
 
-import zio.interop.catz._
 import doobie.util.log.LogHandler
 import io.github.gaelrenoux.tranzactio.doobie._
 import io.github.gaelrenoux.tranzactio.{DbException, ErrorStrategiesRef}
 import samples.{Conf, ConnectionPool, Person}
 import zio._
-import zio.Console
+import zio.interop.catz._
 
 /** A sample app where all modules are linked through ZLayer. Should run as is (make sure you have com.h2database:h2 in
  * your dependencies). */

--- a/examples/src/test/scala/samples/doobie/LayeredAppStreaming.scala
+++ b/examples/src/test/scala/samples/doobie/LayeredAppStreaming.scala
@@ -5,7 +5,6 @@ import io.github.gaelrenoux.tranzactio.{DbException, ErrorStrategiesRef}
 import samples.{Conf, ConnectionPool, Person}
 import zio._
 import zio.stream._
-import zio.Console
 
 /** Same as LayeredApp, but using Doobie's stream (converted into ZIO strem). */
 // scalastyle:off magic.number

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -8,7 +8,7 @@ object BuildHelper {
     val zio = "2.0.15"
     val zioCats = "23.0.0.8"
     val cats = "2.9.0"
-    val doobie = "1.0.0-RC2"
+    val doobie = "1.0.0-RC4"
     val anorm = "2.7.0"
     val h2 = "2.2.220"
     val scala212 = "2.12.18"


### PR DESCRIPTION
See https://github.com/gaelrenoux/tranzactio/issues/47 for issue and discussion. I've introduced a `DbContext` parameter when creating the `Database` layer, allowing to define a `LogHandler` for Doobie.

I could have passed the `DbContext` on every call to `transaction` or `autoCommit`, but I chose to define it at the layer level. Two main reasons:

1. From a usage perspective, it seems more practical to me to define the log-level of your DB layer when defining said layer, instead of defining it every singe time you run the transaction. Sure, this limits a little bit your options, as you cannot customize the `LogHandler` on every `transaction` call, but you can handle that by having multiple `Database` layers (with different logging levels) and using the one you want.

2. From a long-term perspective: my current implementation for Doobie can be improved. I'm recreating a `Transactor` every single time a transaction is run, passing it a single JDBC connection instead of a connections source. This allow me to easily control the transaction from the outside, but it might have performance implications. In the future, I'd like to have a single Transactor for the database layer, where I can control which connection it gets by manipulating the source instead. This would not be compatible with passing a LogHandler on each call to `transaction`.