### PR TITLE
Implement ZStream support

### DIFF
--- a/core/src/main/scala/io/github/gaelrenoux/tranzactio/DatabaseOps.scala
+++ b/core/src/main/scala/io/github/gaelrenoux/tranzactio/DatabaseOps.scala
@@ -1,6 +1,7 @@
 package io.github.gaelrenoux.tranzactio
 
-import zio.{UIO, ZIO, Trace}
+import zio.stream.ZStream
+import zio.{Cause, Trace, UIO, ZIO}
 
 /** Operations for a Database, based on a few atomic operations. Can be used both by the actual DB service, or by the DB
  * component where a Database is required in the resulting ZIO.
@@ -29,6 +30,11 @@ trait DatabaseOps[Connection, R0] {
   )(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent, trace: Trace): ZIO[R with R0, Either[DbException, E], A] =
     transaction[R, E, A](zio, commitOnFailure)
 
+  def transactionStream[R <: Any, E, A](
+      stream: => ZStream[Connection with R, E, A],
+      commitOnFailure: => Boolean = false
+  )(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent, trace: Trace): ZStream[R with R0, Either[DbException, E], A]
+
   /** As `transaction`, but exceptions are simply widened to a common failure type. The resulting failure type is a
    * superclass of both DbException and the error type of the inital ZIO. */
   final def transactionOrWiden[R, E >: DbException, A](
@@ -44,6 +50,12 @@ trait DatabaseOps[Connection, R0] {
   )(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent, trace: Trace): ZIO[R with R0, E, A] =
     transactionOrWiden[R, E, A](zio, commitOnFailure)
 
+  final def transactionOrWidenStream[R, E >: DbException, A](
+      stream: => ZStream[Connection with R, E, A],
+      commitOnFailure: => Boolean = false
+    )(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent, trace: Trace): ZStream[R with R0, E, A] =
+    transactionStream[R, E, A](stream, commitOnFailure).mapError(_.fold(identity, identity))
+
   /** As `transaction`, but errors when handling the connections are treated as defects instead of failures. */
   final def transactionOrDie[R, E, A](
       zio: => ZIO[Connection with R, E, A],
@@ -57,6 +69,18 @@ trait DatabaseOps[Connection, R0] {
       commitOnFailure: => Boolean = false
   )(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent, trace: Trace): ZIO[R with R0, E, A] =
     transactionOrDie[R, E, A](zio, commitOnFailure)
+
+  final def transactionOrDieStream[R, E, A](
+      stream: => ZStream[Connection with R, E, A],
+      commitOnFailure: => Boolean = false
+  )(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent, trace: Trace): ZStream[R with R0, E, A] =
+    transactionStream[R, E, A](stream, commitOnFailure)
+      .mapErrorCause { cause =>
+          cause.flatMap {
+            case Left(dbError) => Cause.die(dbError, cause.trace)
+            case Right(error) => Cause.fail(error, cause.trace)
+          }
+      }
 
   /** Provides that ZIO with a Connection. All DB action in the ZIO will be auto-committed. Failures in the initial
    * ZIO will be wrapped in a Right in the error case of the resulting ZIO, with connection errors resulting in a
@@ -74,6 +98,10 @@ trait DatabaseOps[Connection, R0] {
   )(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent, trace: Trace): ZIO[R with R0, Either[DbException, E], A] =
     autoCommit[R, E, A](zio)
 
+  def autoCommitStream[R, E, A](
+      stream: => ZStream[Connection with R, E, A]
+  )(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent, trace: Trace): ZStream[R with R0, Either[DbException, E], A]
+
   /** As `autoCommit`, but exceptions are simply widened to a common failure type. The resulting failure type is a
    * superclass of both DbException and the error type of the inital ZIO. */
   final def autoCommitOrWiden[R, E >: DbException, A](
@@ -87,6 +115,11 @@ trait DatabaseOps[Connection, R0] {
   )(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent, trace: Trace): ZIO[R with R0, E, A] =
     autoCommitOrWiden[R, E, A](zio)
 
+  final def autoCommitOrWidenStream[R, E >: DbException, A](
+      stream: => ZStream[Connection with R, E, A]
+  )(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent, trace: Trace): ZStream[R with R0, E, A] =
+    autoCommitStream[R, E, A](stream).mapError(_.merge)
+
   /** As `autoCommit`, but errors when handling the connections are treated as defects instead of failures. */
   final def autoCommitOrDie[R, E, A](
       zio: => ZIO[Connection with R, E, A]
@@ -98,6 +131,16 @@ trait DatabaseOps[Connection, R0] {
       zio: => ZIO[Connection with R, E, A]
   )(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent, trace: Trace): ZIO[R with R0, E, A] =
     autoCommitOrDie[R, E, A](zio)
+
+  final def autoCommitOrDieStream[R, E, A](
+      stream: => ZStream[Connection with R, E, A]
+  )(implicit errorStrategies: ErrorStrategiesRef = ErrorStrategies.Parent, trace: Trace): ZStream[R with R0, E, A] =
+    autoCommitStream[R, E, A](stream).mapErrorCause {  cause => cause.flatMap{
+        case Left(dbError) => Cause.die(dbError, cause.trace)
+        case Right(error) => Cause.fail(error, cause.trace)
+      }
+    }
+
 
 }
 

--- a/examples/src/test/scala/samples/doobie/PersonQueries.scala
+++ b/examples/src/test/scala/samples/doobie/PersonQueries.scala
@@ -25,6 +25,7 @@ object PersonQueries {
 
     val setup: TranzactIO[Unit] = tzio {
       sql"""
+        DROP TABLE IF EXISTS person;
         CREATE TABLE person (
           given_name VARCHAR NOT NULL,
           family_name VARCHAR NOT NULL

--- a/examples/src/test/scala/samples/doobie/test/StreamTest.scala
+++ b/examples/src/test/scala/samples/doobie/test/StreamTest.scala
@@ -1,0 +1,64 @@
+package samples.doobie.test
+
+import zio.stream.{ZSink, ZStream}
+import zio.test.Assertion._
+import zio.test._
+import zio.{ZIO, ZLayer}
+
+import io.github.gaelrenoux.tranzactio.DbException
+import io.github.gaelrenoux.tranzactio.doobie._
+
+import samples.doobie.PersonQueries
+import samples.{Conf, ConnectionPool, Person}
+object StreamTest extends ZIOSpec[TestEnvironment with PersonQueries with Database] {
+  type Env = TestEnvironment with PersonQueries with Database
+  type MySpec = Spec[Env, Any]
+
+  private val conf = Conf.live("samble-doobie-app-streaming")
+  private val dbRecoveryConf = conf >>> ZLayer.fromFunction((_: Conf).dbRecovery)
+  private val datasource = conf >>> ConnectionPool.live
+  private val database = (datasource ++ dbRecoveryConf) >>> Database.fromDatasourceAndErrorStrategies
+  private val personQueries = PersonQueries.live
+
+  private val setupLayer = ZLayer.fromZIO(Database.transactionOrDie(PersonQueries.setup)).orDie
+  override def bootstrap: ZLayer[Any, Any, Env] = testEnvironment  ++ personQueries ++ database
+
+  private val insertRow = PersonQueries.insert(Person("Buffy", "Summers"))
+
+  private val failingStream = ZStream.fail(DbException.Wrapped(new Exception()))
+  override def spec: MySpec = suite("Tests ZStream with Doobie")(
+    test("Test ZStream works")(
+      for {
+        database <- ZIO.service[Database]
+        streamPersons: ZStream[PersonQueries, Either[DbException, DbException], Person] = database.transactionStream(PersonQueries.listStream)
+        _ <- database.transactionOrDie(insertRow.replicateZIO(4))
+        persons <- streamPersons.run(ZSink.foldLeft(List[Person]()) { (ps, p) => p :: ps }).mapError(_.merge)
+        // do something with that result
+      } yield assertTrue(persons.length == 4)
+    ),
+    test("Test transaction boundary - fail outside - commit progress")(
+      for {
+        database <- ZIO.service[Database]
+        streamPersons: ZStream[PersonQueries, Either[DbException, DbException], Person] = database.transactionStream(PersonQueries.listStream)
+        insertStream = database.transactionStream(ZStream.fromZIO(insertRow).forever).mapError(_.merge)
+        stream = insertStream.take(2) ++ failingStream ++ insertStream
+        _ <- stream.runDrain.exit
+
+        persons <- streamPersons.run(ZSink.foldLeft(List[Person]()) { (ps, p) => p :: ps }).mapError(_.merge)
+      } yield assertTrue(persons.length == 2)
+    ),
+      test("Test transaction boundary - fail inside - rollback")(
+        for {
+          database <- ZIO.service[Database]
+          streamPersons: ZStream[PersonQueries, Either[DbException, DbException], Person] =
+            database.transactionStream(PersonQueries.listStream)
+          insertStream = database.transactionStream(
+            ZStream.fromZIO(insertRow).forever.take(2) ++ failingStream ++ ZStream.fromZIO(insertRow)
+          ).mapError(_.merge)
+          _ <- insertStream.runDrain.exit
+
+          persons <- streamPersons.run(ZSink.foldLeft(List[Person]()) { (ps, p) => p :: ps }).mapError(_.merge)
+        } yield assertTrue(persons.isEmpty)
+    )
+  ).provideSomeLayer(setupLayer) @@ TestAspect.sequential
+}


### PR DESCRIPTION
Hi I proposing this solution for the https://github.com/gaelrenoux/tranzactio/issues/35 so enable tranzactio to work with ZStream more easily
What are your thoughts about it, could this be okay? 
I added some tests to make sure the transaction boundaries are correct.
In the API I used the ZIO one as inspiration so I have all of them just working with ZStream.