### PR TITLE
feat: tranzactio with doobie 0.13.4 and zio 2

### DIFF
--- a/examples/src/test/scala/samples/doobie/LayeredApp.scala
+++ b/examples/src/test/scala/samples/doobie/LayeredApp.scala
@@ -15,7 +15,7 @@ object LayeredApp extends zio.ZIOAppDefault {
   private val dbRecoveryConf = conf >>> ZLayer.fromFunction((_: Conf).dbRecovery)
   private val datasource = conf >>> ConnectionPool.live
   // The DbContext is optional, default is to have the noop LogHandler
-  implicit val dbContext: DbContext = DbContext(logHandler = LogHandler.jdkLogHandler[Task])
+  implicit val dbContext: DbContext = DbContext(logHandler = LogHandler.jdkLogHandler)
   private val database = (datasource ++ dbRecoveryConf) >>> Database.fromDatasourceAndErrorStrategies
   private val personQueries = PersonQueries.live
 

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -6,9 +6,9 @@ import xerial.sbt.Sonatype.autoImport._
 object BuildHelper {
   object V {
     val zio = "2.0.21"
-    val zioCats = "23.1.0.0"
+    val zioCats = "22.0.0.0"
     val cats = "2.10.0"
-    val doobie = "1.0.0-RC6"
+    val doobie = "0.13.4"
     val anorm = "2.7.0"
     val h2 = "2.2.224"
     val scala212 = "2.12.18"


### PR DESCRIPTION
Hello ! 

We are currently using ZIO 2, but cats-effect is still on 2.x version, so we needed a tranzactio version which is compatible. 

This PR is not made to be pushed on your master branch, but maybe on a parallel version, so that it could be available for those who need it (like us). 